### PR TITLE
Parameter for Graph API version and to force re-prompt of username

### DIFF
--- a/AADGraph.psm1
+++ b/AADGraph.psm1
@@ -72,8 +72,10 @@ function Get-AuthenticationResult {
 
   $authContext = New-Object "Microsoft.IdentityModel.Clients.ActiveDirectory.AuthenticationContext" `
                     -ArgumentList $authority,$false
+
+  $userId = [Microsoft.IdentityModel.Clients.ActiveDirectory.UserIdentifier]::AnyUser
   $authResult = $authContext.AcquireToken($resourceAppIdURI, $clientId, `
-                    $redirectUri, $promptBehavior, $extraQueryParameters)
+                    $redirectUri, $promptBehavior, $userId, $extraQueryParameters)
   return $authResult
 }
 

--- a/AADGraph.psm1
+++ b/AADGraph.psm1
@@ -44,7 +44,18 @@ function Get-AuthenticationResult(){
 }
 
 function Connect-AAD {
-  PROCESS {
+  [CmdletBinding()]
+  param (
+    [parameter(
+        Mandatory=$false,
+        ValueFromPipeline=$true,
+        HelpMessage="The Azure Active Directory Graph API version number: YYYY-MM-DD")]
+    [ValidatePattern("\d{4}-\d{2}-\d{2}")]
+    [string]
+    $GraphApiVersion="2013-11-08"
+  )
+  process {
+    $global:graphApiVersion = $GraphApiVersion
     $global:authenticationResult = $null
     $global:authenticationResult = Get-AuthenticationResult
   }

--- a/Cmdlets/AADGraphObject.psm1
+++ b/Cmdlets/AADGraphObject.psm1
@@ -2,7 +2,7 @@ function Get-AADObject([string]$type) {
   $objects = $null
   if($authenticationResult -ne $null){
     $header = $authenticationResult.CreateAuthorizationHeader()
-    $uri = [string]::Format("https://graph.windows.net/{0}/{1}?api-version=2013-04-05",$authenticationResult.TenantId, $type)
+    $uri = [string]::Format("https://graph.windows.net/{0}/{1}?api-version=${global:graphApiVersion}",$authenticationResult.TenantId, $type)
     Write-Host HTTP GET $uri -ForegroundColor Cyan
     $result = Invoke-WebRequest -Method Get -Uri $uri -Headers @{"Authorization"=$header;"Content-Type"="application/json"}
     if($result.StatusCode -eq 200)
@@ -22,7 +22,7 @@ function Get-AADObjectById([string]$type, [string]$id) {
   $object = $null
   if($global:authenticationResult -ne $null){
     $header = $authenticationResult.CreateAuthorizationHeader()
-    $uri = [string]::Format("https://graph.windows.net/{0}/{1}/{2}?api-version=2013-04-05",$authenticationResult.TenantId, $type.Trim(), $id.Trim())
+    $uri = [string]::Format("https://graph.windows.net/{0}/{1}/{2}?api-version=${global:graphApiVersion}",$authenticationResult.TenantId, $type.Trim(), $id.Trim())
     Write-Host HTTP GET $uri -ForegroundColor Cyan
     $result = Invoke-WebRequest -Method Get -Uri $uri -Headers @{"Authorization"=$header;"Content-Type"="application/json"}
     if($result.StatusCode -eq 200)
@@ -41,7 +41,7 @@ function New-AADObject([string]$type, [object]$object) {
   $newObject = $null
   if($global:authenticationResult -ne $null) {
     $header = $authenticationResult.CreateAuthorizationHeader()
-    $uri = [string]::Format("https://graph.windows.net/{0}/{1}?api-version=2013-04-05",$authenticationResult.TenantId, $type)
+    $uri = [string]::Format("https://graph.windows.net/{0}/{1}?api-version=${global:graphApiVersion}",$authenticationResult.TenantId, $type)
     Write-Host HTTP POST $uri -ForegroundColor Cyan
     $enc = New-Object "System.Text.ASCIIEncoding"
     $body = ConvertTo-Json -InputObject $object
@@ -65,7 +65,7 @@ function New-AADObject([string]$type, [object]$object) {
 function Set-AADObject([string]$type, [string]$id, [object]$object) {
   if($global:authenticationResult -ne $null) {
     $header = $authenticationResult.CreateAuthorizationHeader()
-    $uri = [string]::Format("https://graph.windows.net/{0}/{1}/{2}?api-version=2013-04-05",$authenticationResult.TenantId, $type, $id)
+    $uri = [string]::Format("https://graph.windows.net/{0}/{1}/{2}?api-version=${global:graphApiVersion}",$authenticationResult.TenantId, $type, $id)
     Write-Host HTTP PATCH $uri -ForegroundColor Cyan
     $enc = New-Object "System.Text.ASCIIEncoding"
     $body = ConvertTo-Json -InputObject $object
@@ -87,7 +87,7 @@ function Set-AADObject([string]$type, [string]$id, [object]$object) {
 function Remove-AADObject([string]$type, [string]$id) {
   if($global:authenticationResult -ne $null) {
     $header = $authenticationResult.CreateAuthorizationHeader()
-    $uri = [string]::Format("https://graph.windows.net/{0}/{1}/{2}?api-version=2013-04-05",$authenticationResult.TenantId, $type, $id)
+    $uri = [string]::Format("https://graph.windows.net/{0}/{1}/{2}?api-version=${global:graphApiVersion}",$authenticationResult.TenantId, $type, $id)
     Write-Host HTTP DELETE $uri -ForegroundColor Cyan
     $headers = @{"Authorization"=$header;"Content-Type"="application/json"}
     $result = Invoke-WebRequest -Method Delete -Uri $uri -Headers $headers
@@ -106,8 +106,8 @@ function Get-AADLinkedObject([string]$type, [string] $id, [string]$relationship,
   if($global:authenticationResult -ne $null){
     $header = $authenticationResult.CreateAuthorizationHeader()
     $uri = $null
-    if($getLinksOnly) {$uri = [string]::Format("https://graph.windows.net/{0}/{1}/{2}/$links/{3}?api-version=2013-04-05",$authenticationResult.TenantId, $type, $id, $relationship)}
-    else {$uri = [string]::Format("https://graph.windows.net/{0}/{1}/{2}/{3}?api-version=2013-04-05",$authenticationResult.TenantId, $type, $id, $relationship)}
+    if($getLinksOnly) {$uri = [string]::Format("https://graph.windows.net/{0}/{1}/{2}/$links/{3}?api-version=${global:graphApiVersion}",$authenticationResult.TenantId, $type, $id, $relationship)}
+    else {$uri = [string]::Format("https://graph.windows.net/{0}/{1}/{2}/{3}?api-version=${global:graphApiVersion}",$authenticationResult.TenantId, $type, $id, $relationship)}
     Write-Host HTTP GET $uri -ForegroundColor Cyan
     $result = Invoke-WebRequest -Method Get -Uri $uri -Headers @{"Authorization"=$header;"Content-Type"="application/json"}
     if($result.StatusCode -eq 200)
@@ -127,8 +127,8 @@ function Set-AADObjectProperty([string]$type, [string] $id, [string]$property, [
   if($global:authenticationResult -ne $null) {
     $header = $authenticationResult.CreateAuthorizationHeader()
     $uri = $null
-    if($isLinked) {$uri = [string]::Format('https://graph.windows.net/{0}/{1}/{2}/$links/{3}?api-version=2013-04-05',$authenticationResult.TenantId, $type, $id, $property)}
-    else {$uri = [string]::Format('https://graph.windows.net/{0}/{1}/{2}/{3}?api-version=2013-04-05',$authenticationResult.TenantId, $type, $id, $property)}
+    if($isLinked) {$uri = [string]::Format('https://graph.windows.net/{0}/{1}/{2}/$links/{3}?api-version=${global:graphApiVersion}',$authenticationResult.TenantId, $type, $id, $property)}
+    else {$uri = [string]::Format('https://graph.windows.net/{0}/{1}/{2}/{3}?api-version=${global:graphApiVersion}',$authenticationResult.TenantId, $type, $id, $property)}
     Write-Host HTTP PUT $uri -ForegroundColor Cyan
 
     $body = $null


### PR DESCRIPTION
Sets the Graph API version as a global variable and uses this in all calls.

Usage:
`Connect-AAD` to use the default version of the API. 
`Connect-AAD -GraphApiVersion "2013-04-05"` to use a different version of the API.

Notes:
- Looking to see if there's a way to discover the current version of Graph API.
